### PR TITLE
Corrected filesystem path of „Resources“

### DIFF
--- a/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -97,8 +97,7 @@
 			children = (
 				D95E1BF81D88E01300F94976 /* wk.png */,
 			);
-			name = Resources;
-			path = Tests;
+			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */


### PR DESCRIPTION
Was „Tests“