### PR TITLE
Fix default year type

### DIFF
--- a/configure
+++ b/configure
@@ -55,7 +55,7 @@ substitutions = {
   'com.AN.ORGANIZATION.IDENTIFIER' => 'com.awesome',
   '__AUTHOR NAME__' => 'Mr McAwesome',
   '__TODAYS_DATE__' => Date.today.strftime('%b %-d, %Y'),
-  '__TODAYS_YEAR__' => Date.today.year,
+  '__TODAYS_YEAR__' => "#{Date.today.year}",
   '__GITHUB_USERNAME__' => 'awesome_octocat'
 }
 substitutions.each do |variable, default|


### PR DESCRIPTION
Using a string interpolation to force the default year into a string.

Otherwise, `gsub!` will not work, since the year is returned as a number and it does not know how to convert its type into a string implicitly.

```
./configure:20:in `gsub!': no implicit conversion of Fixnum into String (TypeError)
	from ./configure:20:in `block (3 levels) in replace_variables_in_files'
	from ./configure:19:in `each'
	from ./configure:19:in `block (2 levels) in replace_variables_in_files'
	from ./configure:17:in `open'
	from ./configure:17:in `block in replace_variables_in_files'
	from ./configure:13:in `glob'
	from ./configure:13:in `replace_variables_in_files'
	from ./configure:70:in `<main>'
```