### PR TITLE
add FNM_DOTMATCH to Dir.glob call, fix issue #19

### DIFF
--- a/configure
+++ b/configure
@@ -10,7 +10,7 @@ def prompt_for_variable(variable, default)
 end
 
 def replace_variables_in_files(substitutions)
-  Dir.glob("**/*") do |file_name|
+  Dir.glob("**/*",File::FNM_DOTMATCH) do |file_name|
     next if File.directory?(file_name)
 
     text = ''


### PR DESCRIPTION
Just changes 

    Dir.glob("**/*")

to

    Dir.glob("**/*",File::FNM_DOTMATCH)


which causes the script to iterate over all hidden files and thus fixes the .travis problem.