### PR TITLE
Pre-define answers via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ You then add all the interesting features you want your module to have.
 
 You distribute an example app with your new Swift module to show that it works. You may also decide to add UI tests to your example app and some people like to use testing frameworks for those UI tests. If you would like to use CocoaPods to manage the dependencies of your example app, please see the discussion at https://github.com/fulldecent/swift3-module-template/issues/8.
 
+### Setting up pre-defined answers
+
+You can set up pre-defined answers (e.&nbsp;g. for scripting) in the following ways:
+
+| Template variable | Ways to pre-define the variable | Example |
+| ----------------- | ------------------------------- | ------- |
+| **`__PROJECT_NAME__`** | To pre-define an answer, **pass your project name** to the `./configure` program as a single command-line parameter.<br/>Alternatively, you can use the **`SMT_PROJECT_NAME`** environment variable. | `./configure MyFantasticProject` |
+| **`__ORGANIZATION NAME__`** | To pre-define an answer, define an environment variable named **`SMT_ORGANIZATION_NAME`**. | `export SMT_ORGANIZATION_NAME='Awesome Org'` |
+| **`com.AN.ORGANIZATION.IDENTIFIER`** | To pre-define an answer, define an environment variable named **`SMT_COM_AN_ORGANIZATION_IDENTIFIER`**. | `export SMT_COM_AN_ORGANIZATION_IDENTIFIER='com.awesome'` |
+| **`__AUTHOR NAME__`** | To pre-define an answer, define an environment variable named **`SMT_AUTHOR_NAME`**. | `export SMT_AUTHOR_NAME='Mr McAwesome'` |
+| **`__TODAYS_DATE__`** | To pre-define an answer, define an environment variable named **`SMT_TODAYS_DATE`**. | `export SMT_TODAYS_DATE='her birthday'` |
+| **`__TODAYS_DATE__`** (date format) | As an alternative to the `SMT_TODAYS_DATE` environment variable, you can use **`SMT_DATE_FORMAT_STRING`** to pre-define a date format. The program will still ask you for today’s date; however, it will use the format provided in this variable. | `export SMT_DATE_FORMAT_STRING='%F'` |
+| **`__TODAYS_YEAR__`** | To pre-define an answer, define an environment variable named **`SMT_TODAYS_YEAR`**. | `export SMT_TODAYS_YEAR='2077'` |
+| **`__GITHUB_USERNAME__`** | To pre-define an answer, define an environment variable named **`SMT_GITHUB_USERNAME`**. | `export SMT_GITHUB_USERNAME='awesome_octocat'` |
+
+If an answer is pre-defined, the `./configure` program will use it; otherwise, it will ask for an answer interactively. If neither is given, it will fall back to the built-in default values.
+
 ## Contributing
 
 See the file [`Recipe.md`](Recipe.md) for the complete steps (e.g. Open Xcode, make new project, click here, type that, ...) of how we made the template.

--- a/configure
+++ b/configure
@@ -44,6 +44,41 @@ def replace_variables_in_file_names(substitutions)
   end
 end
 
+module Env
+  class << self
+    ENV_VARIABLE_PREFIX = 'SMT'
+
+    def fetch_smt(template_var_name, *args, &b)
+      environment_var_name = name_for(template_var_name.to_s)
+      ENV.fetch(environment_var_name) do
+        fallback(environment_var_name, template_var_name, *args, &b)
+      end
+    end
+
+    def date_format_string
+      @date_format_string ||=
+        fetch_smt(:DATE_FORMAT_STRING, '%b %-d, %Y')
+    end
+
+    def name_for(template_var_name)
+      "#{ ENV_VARIABLE_PREFIX }_#{ sanitize(template_var_name) }"
+    end
+
+    private
+
+    def fallback(environment_var_name, template_var_name, *args)
+      if block_given?
+        yield(template_var_name, *args)
+      else
+        ENV.fetch(environment_var_name, *args)
+      end
+    end
+
+    def sanitize(template_var_name)
+      template_var_name.upcase.gsub(/\W/, '_').gsub(/^_+|_+$/, '')
+    end
+  end
+end
 
 ##
 ## MAIN
@@ -54,12 +89,13 @@ substitutions = {
   '__ORGANIZATION NAME__' => 'Awesome Org',
   'com.AN.ORGANIZATION.IDENTIFIER' => 'com.awesome',
   '__AUTHOR NAME__' => 'Mr McAwesome',
-  '__TODAYS_DATE__' => Date.today.strftime('%b %-d, %Y'),
+  '__TODAYS_DATE__' => Date.today.strftime(Env.date_format_string),
   '__TODAYS_YEAR__' => "#{Date.today.year}",
   '__GITHUB_USERNAME__' => 'awesome_octocat'
 }
 substitutions.each do |variable, default|
-  substitutions[variable] = prompt_for_variable(variable, default)
+  substitutions[variable] =
+    Env.fetch_smt(variable, default, &method(:prompt_for_variable))
 end
 substitutions['--PROJECT-NAME--'] = substitutions['__PROJECT_NAME__']
 


### PR DESCRIPTION
If ran regularly, it might be useful for the `./configure` program to accept pre-defined answers to the interactive questions.

To that end, this PR adds support for eight environment variables.

## Summary

This PR adds support for the following environment variables:

| Template variable | Ways to pre-define | Example |
| ----------------- | ------------------------------- | ------- |
| **`__ORGANIZATION NAME__`** | To pre-define an answer, define an environment variable named **`SMT_ORGANIZATION_NAME`**<sup>1</sup>. | `export SMT_ORGANIZATION_NAME='Awesome Org'` |
| **`com.AN.ORGANIZATION.IDENTIFIER`** | To pre-define an answer, define an environment variable named **`SMT_COM_AN_ORGANIZATION_IDENTIFIER`**. | `export SMT_COM_AN_ORGANIZATION_IDENTIFIER='com.awesome'` |
| **`__AUTHOR NAME__`** | To pre-define an answer, define an environment variable named **`SMT_AUTHOR_NAME`**. | `export SMT_AUTHOR_NAME='Mr McAwesome'` |
| **`__TODAYS_DATE__`** | To pre-define an answer, define an environment variable named **`SMT_TODAYS_DATE`**.<br/><br/>Alternatively, you can use **`SMT_DATE_FORMAT_STRING`** to pre-define a date format. The program will still ask you for today’s date; however, it will use the format provided in this variable. | `export SMT_TODAYS_DATE='her birthday'`<br/><br/>`export SMT_DATE_FORMAT_STRING='%F'` |
| **`__TODAYS_YEAR__`** | To pre-define an answer, define an environment variable named **`SMT_TODAYS_YEAR`**. | `export SMT_TODAYS_YEAR='2077'` |
| **`__GITHUB_USERNAME__`** | To pre-define an answer, define an environment variable named **`SMT_GITHUB_USERNAME`**. | `export SMT_GITHUB_USERNAME='awesome_octocat'` |
| **`__PROJECT_NAME__`** | As an alternative to passing your project name as a single command-line argument to `./configure`, this PR also supports the **`SMT_PROJECT_NAME`** environment variable. The command-line-argument should remain the preferred way; I only added this variable to maintain consistency. | `./configure MyFantasticProject` remains the preferred way to do this. |

<sub>**\[1\]** `SMT` is just a short-hand for _Swift module template_.</sub>

If any of the above environment variables is defined, the `./configure` program will use its value in lieu of asking interactively; if the variable is undefined, the program will prompt as usual. If neither is successful, it will fall back to the built-in default values.

## Specifying a default format string

The `SMT_DATE_FORMAT_STRING` variable is a special case; if it is defined, the `./configure` program will still ask for today’s date interactively; however, it will use the provided date format.

## Documentation

This PR adds a new section *Setting up pre-defined answers* to `README.md`.
