### PR TITLE
Fix main storyboard

### DIFF
--- a/Recipe.md
+++ b/Recipe.md
@@ -233,7 +233,7 @@ Complete all these instructions on the same calendar day.
         1.  Use Terminal.app to insert some files into the project
 
                 cd ~/Desktop/__PROJECT_NAME__/iOS\ Example/
-                curl 'https://raw.githubusercontent.com/fulldecent/swift-package/master/__PROJECT_NAME__/iOS\ Example/Source/Base.lproj/Main.storyboard' -o Source/Base.lproj/Main.storyboard
+                curl 'https://raw.githubusercontent.com/fulldecent/swift-package/master/__PROJECT_NAME__/iOS%20Example/Source/Base.lproj/Main.storyboard' -o Source/Base.lproj/Main.storyboard
 
     8.  Define packaging files for your module
 

--- a/__PROJECT_NAME__/iOS Example/iOS Example.xcodeproj/project.pbxproj
+++ b/__PROJECT_NAME__/iOS Example/iOS Example.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		D9337FFA1DF4B24E001596B5 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		D9337FFA1DF4B24E001596B5 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		D9899DF21DF4A53C008766B5 /* iOS Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9899DF51DF4A53C008766B5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D9899DF71DF4A53C008766B5 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
## Fix recipe step

In step 3.7.1 of the recipe, the command to install the example `Main.storyboard` file uses shell escaping:

3\. Create a project for your iOS Example project
&nbsp;&nbsp;&nbsp;&nbsp;7\. Add source code with some functionality to the example
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1\. Use Terminal.app to insert some files into the project

>         `cd ~/Desktop/__PROJECT_NAME__/iOS\ Example/`
>         `curl 'https://`…**`iOS\ Example`**`/Source/Base.lproj/Main.storyboard' -o `…

which results in a 404 error.

The PR at hand replaces the shell encoding by URL encoding so the command works:

>         `curl 'https://`…**`iOS%20Example`**`/Source/Base.lproj/Main.storyboard' -o `…

## Fix storyboard reference

The PR also fixes a broken reference related to `Main.storyboard` in one of the `project.pbxproj` files, which resulted in a compile error for the iOS example project. That reference now correctly points to `Base.proj/Main.storyboard`.
