### PR TITLE
Remove development team ID

### DIFF
--- a/Recipe.md
+++ b/Recipe.md
@@ -271,6 +271,12 @@ Complete all these instructions on the same calendar day.
 
         2.  Replace occurrences of "Copyright © 2017" with "Copyright © `__TODAYS_YEAR__`"
 
+    2.  Use Terminal.app to remove all references to development team IDs
+
+            find ~/Desktop/__PROJECT_NAME__ -name project.pbxproj \
+                -exec sed -i '' -E -e '/DevelopmentTeam = /d
+                    s/(DEVELOPMENT_TEAM = )[^;]+/\1""/' '{}' \;
+
 6.  Use Terminal.app to add additional files to the project
 
         cd ~/Desktop/__PROJECT_NAME__/

--- a/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -162,13 +162,11 @@
 				TargetAttributes = {
 					D9899DC91DF4A091008766B5 = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = 8Q693ZG5RN;
 						LastSwiftMigration = 0810;
 						ProvisioningStyle = Automatic;
 					};
 					D9899DD21DF4A092008766B5 = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = 8Q693ZG5RN;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -342,7 +340,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 8Q693ZG5RN;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -363,7 +361,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 8Q693ZG5RN;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -381,7 +379,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				DEVELOPMENT_TEAM = 8Q693ZG5RN;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = __PROJECT_NAME__Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.AN.ORGANIZATION.IDENTIFIER.--PROJECT-NAME--Tests";
@@ -394,7 +392,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				DEVELOPMENT_TEAM = 8Q693ZG5RN;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = __PROJECT_NAME__Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.AN.ORGANIZATION.IDENTIFIER.--PROJECT-NAME--Tests";

--- a/__PROJECT_NAME__/iOS Example/iOS Example.xcodeproj/project.pbxproj
+++ b/__PROJECT_NAME__/iOS Example/iOS Example.xcodeproj/project.pbxproj
@@ -108,7 +108,6 @@
 				TargetAttributes = {
 					D9899DF11DF4A53C008766B5 = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = 8Q693ZG5RN;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -265,7 +264,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 8Q693ZG5RN;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Source/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.AN.ORGANIZATION.IDENTIFIER.iOS-Example";
@@ -278,7 +277,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 8Q693ZG5RN;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Source/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.AN.ORGANIZATION.IDENTIFIER.iOS-Example";


### PR DESCRIPTION
This PR **removes all occurrences of the development team ID** from `project.pbxproj` files, which would lead to unsightly warnings if Xcode does not know that particular team ID.

The PR also updates the recipe to reflect this change. Since the recipe already assumes we’re on macOS, we can use (the macOS flavors of) `find` and `sed` to **find and replace such IDs via Terminal.app**. I feel this is more convenient than manual search-and-replace; besides, no text editor is needed while executing that step.
