### PR TITLE
Automate search-replace steps in recipe

### DIFF
--- a/Recipe.md
+++ b/Recipe.md
@@ -265,11 +265,14 @@ Complete all these instructions on the same calendar day.
 
 5.  Remove identifying parts of your project
 
-    1.  Use Atom text editor to find and replace all occurrences of these strings (NEED A MORE PORTABLE INSTRUCTION FOR THIS)
+    1.  Use Terminal.app to find and replace all occurrences of hard-coded strings with template variables
 
-        1.  Replace occurrences of "Created by XXX on YYY." with "Created by `__AUTHOR NAME__` on `__TODAYS_DATE__`."
+            find -E ~/Desktop/__PROJECT_NAME__ \
+                -regex '.*\.(h|swift)' -exec sed -i '' -E -e '
+                    s-(// +Created by ).*( on ).*\.-\1__AUTHOR NAME__\2__TODAYS_DATE__.-
+                    s-(// +Copyright © ).*-\1__TODAYS_YEAR__ __ORGANIZATION NAME__. All rights reserved.-' \
+                '{}' \;
 
-        2.  Replace occurrences of "Copyright © 2017" with "Copyright © `__TODAYS_YEAR__`"
 
 6.  Use Terminal.app to add additional files to the project
 


### PR DESCRIPTION
Just like in PR #30, this PR tries to leverage the (macOS flavor of) `find` and `sed` to **automate the execution of steps 5.1.1 and 5.1.2.** in the recipe, ultimately merging both into a single step of 5.1.

Hopefully, this saves template maintainers a bit of time when executing those recipe steps, and seems less tedious to me than the manual process. It also loses the dependency on the text editor.
