### PR TITLE
Promote rook to king

### DIFF
--- a/Recipe.md
+++ b/Recipe.md
@@ -296,4 +296,4 @@ Complete all these instructions on the same calendar day.
 
 3.  Select Product -> Run
 
-You should see a big white rook. That means it worked!
+You should see a big white king. That means it worked!


### PR DESCRIPTION
I don’t mean to be a smarty-pants (nobody likes smarty-pants, right?) However, I’ve heard some legislations consider [lese-majesty](https://en.wikipedia.org/wiki/L%C3%A8se-majest%C3%A9) a [criminal offence](https://en.wikipedia.org/wiki/L%C3%A8se-majest%C3%A9#Current_laws). I belive that’s the waters into which we’re going to get unless we stop calling a [king](https://github.com/fulldecent/swift3-module-template/blob/9fdf9a2cad9c9b7ad5ec10c4574b5707f7f92c8a/__PROJECT_NAME__/Resources/wk.png) a [rook](https://en.wikipedia.org/wiki/Rook_(chess)).

![White rook](https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Chess_piece_-_White_rook.JPG/133px-Chess_piece_-_White_rook.JPG) ![Black rook](https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Chess_piece_-_Black_rook.JPG/131px-Chess_piece_-_Black_rook.JPG)

Some countries go as far as to [prosecute you for insulting a king of a FOREIGN state](https://en.wikipedia.org/wiki/Freedom_of_speech_by_country#Germany). (Admittedly, we haven’t had a monarch for 99 years so what else are we supposed to do?)

I feel we should **reconsider calling a monarch a rook**, and maybe start treading a bit more carefully in the presence of kings, and generally try not to call a king any name that might offend him. You know how highly strung a king gets.

Kings are just too damn powerful. Please let us not mess with them.