### PR TITLE
Fixed tests target (path to Info.plist was wrong, so tests didn't run)

### DIFF
--- a/Recipe.md
+++ b/Recipe.md
@@ -117,6 +117,14 @@ Complete all these instructions on the same calendar day.
 
             5.  Edit the "Info.plist File" to be "Source/Info.plist"
 
+            6.  Click the target `__PROJECT_NAME__Tests` in the middle (the grey Lego block icon)
+
+            7.  Click "Build Settings" on the top of the middle
+
+            8.  Enter "Info.plist" in the search box
+
+            9.  Edit the "Info.plist File" to be "Tests/Info.plist"
+
     7.  Add source code with some functionality to the module
 
         1.  Use Terminal.app to insert some files into the project

--- a/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = __PROJECT_NAME__Tests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.AN.ORGANIZATION.IDENTIFIER.--PROJECT-NAME--Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/__PROJECT_NAME__/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -395,7 +395,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = __PROJECT_NAME__Tests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.AN.ORGANIZATION.IDENTIFIER.--PROJECT-NAME--Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -422,6 +422,7 @@
 				D93F1CAE1EAEDB6E009A7474 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D93F1CAF1EAEDB6E009A7474 /* Build configuration list for PBXNativeTarget "__PROJECT_NAME__Tests" */ = {
 			isa = XCConfigurationList;
@@ -430,6 +431,7 @@
 				D93F1CB11EAEDB6E009A7474 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
When I created a project using "./configure", then opened Xcode and hit "Cmd+U" (to run the tests). Xcode can't find Info.plistor the tests, because in a base project it is located in Tests folder, but in project.pbxproj it was "__PROJECT_NAME__Tests/Info.plist". Removing "__PROJECT_NAME__" in plist path fixed the problem.

P.S. Thanks a lot for this template - very useful.