### PR TITLE
Added ObjC files so Pod can contain Swift and ObjC code

### DIFF
--- a/__PROJECT_NAME__/__PROJECT_NAME__.podspec
+++ b/__PROJECT_NAME__/__PROJECT_NAME__.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.authors = { 'PROJECT_OWNER' => 'USER_EMAIL' }
   s.source = { :git => 'https://github.com/__GITHUB_USERNAME__/__PROJECT_NAME__.git', :tag => s.version }
   s.ios.deployment_target = '8.0'
-  s.source_files = 'Source/*.swift'
+  s.source_files = 'Source/*.{h,m,swift}'
   s.resource_bundles = {
     '__PROJECT_NAME__' => ['Resources/**/*.{png}']
   }


### PR DESCRIPTION
I don't know why you decided to split templates for Objective-C and Swift.
I've tried just adding Objective-C file extensions to *.podspec and it worked, so with this change template can work for both Swift and Objective-C code (and have interoperability with them inside).